### PR TITLE
Remove active cell configuration if OhTeePeeInput is disabled

### DIFF
--- a/ohteepee/src/main/java/com/composeuisuite/ohteepee/OhTeePeeCell.kt
+++ b/ohteepee/src/main/java/com/composeuisuite/ohteepee/OhTeePeeCell.kt
@@ -66,6 +66,7 @@ internal fun OhTeePeeCell(
         key3 = isErrorOccurred
     ) {
         val config = when {
+            !enabled -> if (value.isEmpty()) configurations.emptyCellConfig else configurations.filledCellConfig
             isErrorOccurred -> configurations.errorCellConfig
             isFocused -> configurations.activeCellConfig
             value.isNotEmpty() -> configurations.filledCellConfig


### PR DESCRIPTION
Scenario. 
1. User has clicked on the nth cell. 
2. OTP is autofilled from SMS
3. developer disables the field editing till otp is being verified.
4. During this time, none of the cell should be in active state. 