### PR TITLE
Change default keyboard type

### DIFF
--- a/ohteepee/src/main/java/com/composeuisuite/ohteepee/OhTeePeeCell.kt
+++ b/ohteepee/src/main/java/com/composeuisuite/ohteepee/OhTeePeeCell.kt
@@ -141,7 +141,8 @@ internal fun OhTeePeeCell(
                 .background(cellConfiguration.backgroundColor),
             keyboardOptions = KeyboardOptions(
                 keyboardType = keyboardType,
-                imeAction = ImeAction.Next
+                imeAction = ImeAction.Next,
+                autoCorrect = false,
             ),
             keyboardActions = KeyboardActions(
                 onNext = {},

--- a/ohteepee/src/main/java/com/composeuisuite/ohteepee/OhTeePeeInput.kt
+++ b/ohteepee/src/main/java/com/composeuisuite/ohteepee/OhTeePeeInput.kt
@@ -65,7 +65,7 @@ fun OhTeePeeInput(
     configurations: OhTeePeeConfigurations,
     modifier: Modifier = Modifier,
     isValueInvalid: Boolean = false,
-    keyboardType: KeyboardType = KeyboardType.Number,
+    keyboardType: KeyboardType = KeyboardType.NumberPassword,
     enabled: Boolean = true,
     autoFocusByDefault: Boolean = true
 ) {


### PR DESCRIPTION
Also remove autocorrection on the keyboard.

Although the developer can change the keyboard type, I believe this is a more appropriate keyboard for OTPs which do not have options for `-` and `Space`

![Screenshot 2023-10-19 at 11 19 26 AM](https://github.com/composeuisuite/ohteepee/assets/6739498/9cffd1ff-0fac-4e1c-9e6b-5915ec1991b4)
