### PR TITLE
[feat] Add support not to clear the input on error

### DIFF
--- a/ohteepee/src/main/java/com/composeuisuite/ohteepee/OhTeePeeInput.kt
+++ b/ohteepee/src/main/java/com/composeuisuite/ohteepee/OhTeePeeInput.kt
@@ -101,7 +101,11 @@ fun OhTeePeeInput(
     val cellsCount = configurations.cellsCount
     val placeHolderAsChar = placeHolder.first()
     val otpValueCharArray: CharArray by remember(value, isValueInvalid) {
-        val charArray = getOtpValueCharArray(cellsCount, isValueInvalid, value)
+        val charArray = getOtpValueCharArray(
+            cellsCount = cellsCount,
+            shouldClearInput = isValueInvalid && configurations.clearInputOnError,
+            value = value,
+        )
         mutableStateOf(charArray)
     }
     val focusManager = LocalFocusManager.current
@@ -141,7 +145,9 @@ fun OhTeePeeInput(
 
     if (isValueInvalid) {
         LaunchedEffect(Unit) {
-            focusRequester.first().requestFocus()
+            if (configurations.clearInputOnError) {
+                focusRequester.first().requestFocus()
+            }
 
             if (configurations.errorAnimationConfig != null) {
                 triggerErrorAnimation(configurations.errorAnimationConfig, shakeErrorAnimatable)
@@ -258,11 +264,11 @@ private fun OhTeePeeInput(
 
 private fun getOtpValueCharArray(
     cellsCount: Int,
-    isValueInvalid: Boolean,
+    shouldClearInput: Boolean,
     value: String,
 ): CharArray {
     val charList = CharArray(cellsCount) { index ->
-        if (isValueInvalid) {
+        if (shouldClearInput) {
             NOT_ENTERED_VALUE
         } else {
             value.getOrNull(index)

--- a/ohteepee/src/main/java/com/composeuisuite/ohteepee/configuration/OhTeePeeConfigurations.kt
+++ b/ohteepee/src/main/java/com/composeuisuite/ohteepee/configuration/OhTeePeeConfigurations.kt
@@ -35,6 +35,8 @@ private const val DEFAULT_PLACE_HOLDER = " "
  * @param errorCellConfig [OhTeePeeCellConfiguration] cell ui configuration when an error occurred.
  * @param emptyCellConfig [OhTeePeeCellConfiguration] cell ui configuration when it's empty & not focused.
  * @param filledCellConfig [OhTeePeeCellConfiguration] cell ui configuration when it's filled.
+ * @param clearInputOnError when set to `true`, the input will be cleared and the focus will be reset to the first char
+ * when an error occurred.
  * @param enableBottomLine when set to `true`, a bottom line will be drawn for each
  * cell instead of full shape using the other cell configurations.
  * @param errorAnimationConfig [OhTeePeeErrorAnimationConfig] animation config when an error occurred.
@@ -53,6 +55,7 @@ data class OhTeePeeConfigurations(
     val errorCellConfig: OhTeePeeCellConfiguration,
     val emptyCellConfig: OhTeePeeCellConfiguration,
     val filledCellConfig: OhTeePeeCellConfiguration,
+    val clearInputOnError: Boolean,
     val enableBottomLine: Boolean,
     val errorAnimationConfig: OhTeePeeErrorAnimationConfig?,
 ) {
@@ -73,6 +76,7 @@ data class OhTeePeeConfigurations(
                 .size(48.dp),
             elevation: Dp = 0.dp,
             cursorColor: Color = Color.Transparent,
+            clearInputOnError: Boolean = true,
             enableBottomLine: Boolean = false,
             obscureText: String = String.EMPTY,
             placeHolder: String = DEFAULT_PLACE_HOLDER,
@@ -85,6 +89,7 @@ data class OhTeePeeConfigurations(
             emptyCellConfig = emptyCellConfig,
             filledCellConfig = filledCellConfig,
             cursorColor = cursorColor,
+            clearInputOnError = clearInputOnError,
             enableBottomLine = enableBottomLine,
             placeHolder = placeHolder,
             obscureText = obscureText,

--- a/sample/src/main/java/com/composeuisuite/ohteepee/MainActivity.kt
+++ b/sample/src/main/java/com/composeuisuite/ohteepee/MainActivity.kt
@@ -339,6 +339,12 @@ private fun Sample2(
         Spacer(modifier = Modifier.height(16.dp))
 
         Text(
+            text = "(Keep input on error)",
+            color = Color.White,
+            textAlign = TextAlign.Center,
+        )
+
+        Text(
             text = "Please type the verification code sent to +1111111111",
             color = Color.White,
             textAlign = TextAlign.Center,
@@ -359,6 +365,7 @@ private fun Sample2(
                 cellModifier = Modifier
                     .padding(horizontal = 4.dp)
                     .size(48.dp),
+                clearInputOnError = false,
             ),
             autoFocusByDefault = false,
             modifier = Modifier


### PR DESCRIPTION
resolves #30 

## What happened 👀

- Add `clearInputOnError` option to not clear the input on error.

## Proof Of Work 📹

There are quite many samples in this demo project, so I decided to update the third sample to set `clearInputOnError = false`.

https://github.com/user-attachments/assets/aa174dba-9c59-4c98-86b5-68e924dc5895


